### PR TITLE
fix(popup): render nextResetLabel in UTC

### DIFF
--- a/src/lib/popup-format.ts
+++ b/src/lib/popup-format.ts
@@ -48,7 +48,7 @@ export function nextResetLabel(now: Date = new Date()): string {
   const next = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1),
   );
-  return next.toLocaleDateString("en-US", { month: "long", day: "numeric" });
+  return next.toLocaleDateString("en-US", { month: "long", day: "numeric", timeZone: "UTC" });
 }
 
 export function resetsAtLabel(resetsAtIso: string | undefined): string {


### PR DESCRIPTION
## Summary
Two unit tests in `test/ui/popup-format.test.ts` fail on any machine west of UTC ("expected 'May 31' to be 'June 1'"). Root cause: `nextResetLabel` builds the date at UTC midnight on the 1st but formats it **without** `timeZone: "UTC"`, so the label shifts back one day in negative-offset timezones. `resetsAtLabel` already passed `timeZone` — this aligns the fallback path.

User-visible impact: popup showed the wrong credits-reset date (e.g. "May 31" instead of "June 1") for all users in the Americas.

## Test
`npx vitest run test/ui/popup-format.test.ts` → 25/25 pass (was 23/25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)